### PR TITLE
Consolidate workspaces into v2: extract logic to testable scripts, fix bugs, add tests & docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: [main, v2]
+  pull_request:
+
+jobs:
+  scripts:
+    name: Script logic (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['18', '20', '22']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Run test harness
+        run: ./test/run-tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,134 +1,195 @@
 # TS Stricter
 
-This GitHub Action helps you **iteratively migrate** your **unstrict** TypeScript codebase to a **strict** one. It does this by **comparing the TypeScript error count** on your pull request's **HEAD** branch vs. the **BASE** branch and **fails** the workflow if new errors have been introduced.  
+**Migrate an un-strict TypeScript codebase to `strict` mode, one pull request at a time — without ever blocking a build.**
 
-By ensuring that your error count never goes up, your team can gradually reduce existing errors over time—eventually reaching a fully strict codebase without sudden disruptions.
+`ts-stricter` is a GitHub Action that counts the TypeScript errors your code _would_ have under `strict` mode on your PR branch (**HEAD**) and on the target branch (**BASE**), and **fails the check only if the count went up**. Existing errors are grandfathered in; new ones are not. Your team chips away at the backlog on its own schedule, and the number only ever goes down.
 
-## Features
+---
 
-- 🔄 **Flexible Installation**: Support for npm, yarn, and pnpm with customizable install commands
-- 💾 **Dependency Caching**: Optional caching to speed up your workflows
-- 🛠 **Prebuild Support**: Run custom commands before TypeScript compilation
-- ⚙️ **TypeScript Configuration**: Use your own tsconfig.json with strict mode enforcement
-- 📊 **Error Tracking**: Detailed error count comparison with configurable failure thresholds
-- 🧩 **Modular Design**: Use the full workflow or individual composite actions for custom needs
+## The problem
 
-## Usage
+You want `strict: true`, but flipping it on lights up thousands of errors and breaks every build. So it stays off, and the codebase keeps accruing the exact problems strict mode would have caught. A big-bang migration never gets prioritized.
 
-### Basic Usage
+## The idea: a ratchet, not a cliff
 
-In your repository, create or update a GitHub Actions workflow file (e.g. `.github/workflows/compare-tsc-errors.yml`) with the following:
+Instead of demanding zero errors, `ts-stricter` enforces **"no more errors than before."** Each PR is allowed to leave the strict-error count flat or lower it — never raise it. The build is never blocked by the pre-existing backlog, but the backlog can only shrink.
+
+---
+
+## Recommended setup: strict **on** in the editor, **off** in the build
+
+> **Developers won't fix what they can't see.** If strict errors only surface in CI, people discover at PR time that they accidentally added some — which is annoying, so they skip or work around the check instead of fixing it. The fix is to make strict errors visible *while you code*, and keep them out of the build so nothing breaks.
+
+The pattern that makes this work is **two tsconfigs**:
+
+**`tsconfig.json`** — strict **on**. This is what your editor (VS Code, etc.) reads, so every developer sees strict errors as red squiggles in real time.
+
+```jsonc
+{
+  "compilerOptions": {
+    "strict": true
+    // ...the rest of your options
+  }
+}
+```
+
+**`tsconfig.build.json`** — strict **off**, for anything that must keep compiling today (bundlers, `tsc --build`, CI type-checks):
+
+```jsonc
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": false
+  }
+}
+```
+
+Point your build/type-check scripts at the relaxed config so they don't fail on the existing backlog:
+
+```jsonc
+// package.json
+{
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit"
+  }
+}
+```
+
+Then let **`ts-stricter` be the thing that enforces strictness** — it runs with `--strict` forced on (`strict-override: true`, the default) and only fails when the count increases. Developers see errors live, builds stay green, and the ratchet does the rest.
+
+---
+
+## Quick start
+
+Create `.github/workflows/ts-stricter.yml`:
 
 ```yaml
-name: Compare TSC Errors
+name: TS Stricter
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
-  compare-tsc-errors:
+  ts-stricter:
     runs-on: ubuntu-latest
     steps:
-      - name: Compare TSC on HEAD vs BASE
-        uses: thinkdx/ts-stricter@v2
+      - uses: thinkdx/ts-stricter@v2
 ```
 
-### Advanced Usage
+That's it. On every PR the action installs deps, runs `tsc --strict` on BASE and HEAD, and fails if HEAD has more errors.
+
+### A more configured example
 
 ```yaml
-name: Compare TSC Errors
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-
-jobs:
-  compare-tsc-errors:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Compare TSC on HEAD vs BASE
-        uses: thinkdx/ts-stricter@v2
-        with:
-          # Installation options
-          package-manager: 'yarn'           # npm, yarn, or pnpm (default: npm)
-          cache-dependencies: true                # Enable dependency caching (default: true)
-          install-command: 'yarn install'   # Custom install command (optional)
-          node-version: '18'               # Node.js version (default: 18)
-          
-          # TypeScript options
-          working-directory: './packages/core'  # Directory to run in (default: .)
-          tsconfig: 'tsconfig.strict.json'     # Custom tsconfig path (default: tsconfig.json)
-          strict-override: true                # Force strict mode (default: true)
-          
-          # Build options
-          prebuild-command: 'yarn build:deps'  # Command to run before TSC (optional)
-          prebuild-working-directory: '.'      # Prebuild working directory (default: .)
-```
-
-## Composite Actions
-
-This package includes several composite actions that can be used independently:
-
-### TypeScript Check (`./typescript`)
-
-Run TypeScript compiler and count errors:
-
-```yaml
-- uses: thinkdx/ts-stricter/typescript@v2
+- uses: thinkdx/ts-stricter@v2
   with:
-    working-directory: '.'
-    tsconfig: 'tsconfig.json'
-    strict-override: true
-    prebuild-command: ''
-    prebuild-working-directory: '.'
+    package-manager: pnpm          # npm | yarn | pnpm
+    node-version-file: .nvmrc      # or node-version: '20'
+    working-directory: ./app
+    tsconfig: tsconfig.json        # strict is forced regardless of what this says
+    prebuild-command: pnpm codegen # e.g. generate types before tsc
 ```
 
-### Dependency Installation (`./install`)
+---
 
-Install Node.js dependencies with caching:
+## How it works
+
+1. Check out **BASE**, install dependencies, run `tsc --strict --noEmit`, count errors.
+2. Check out **HEAD** (the merge commit by default), install, run the same, count errors.
+3. Compare. If HEAD > BASE, fail the check (unless `fail-on-increase: false`).
+
+The error count is parsed from `tsc`'s summary line (`Found N errors…`), so a clean run counts as `0`.
+
+---
+
+## Workspaces / monorepos
+
+For repos with several packages, each with its **own `tsconfig.json`**, run in workspace mode. Each package is counted independently and **any** package regressing fails the check.
 
 ```yaml
-- uses: thinkdx/ts-stricter/install@v2
+- uses: thinkdx/ts-stricter@v2
   with:
-    package-manager: 'npm'
-    working-directory: '.'
-    cache-dependencies: true
-    install-command: ''
-    node-version: '18'
+    is-workspace: true
+    workspace-packages: |
+      packages/app, packages/ui, packages/server
+    workspace-prebuild-command: pnpm -r build   # runs once at the repo root first
 ```
 
-### Error Comparison (`./compare`)
+Per-package error counts and differences are exposed as JSON outputs (`package-errors`, `package-differences`).
 
-Compare TypeScript error counts:
+---
 
-```yaml
-- uses: thinkdx/ts-stricter/compare@v2
-  with:
-    head-errors: '10'
-    base-errors: '12'
-```
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `working-directory` | `.` | Directory to run TypeScript in. |
+| `package-manager` | `npm` | `npm`, `yarn`, or `pnpm`. |
+| `cache-dependencies` | `true` | Cache the package manager's store between runs. |
+| `install-command` | _(auto)_ | Override the default install command. |
+| `node-version` | _(none)_ | Node.js version to set up. |
+| `node-version-file` | _(none)_ | Path to a version file (e.g. `.nvmrc`). |
+| `tsconfig` | `tsconfig.json` | tsconfig to use, relative to `working-directory` (or to each package in workspace mode). |
+| `strict-override` | `true` | Force `--strict` regardless of the tsconfig. |
+| `prebuild-command` | _(none)_ | Command to run before `tsc` (e.g. codegen). |
+| `prebuild-working-directory` | `.` | Working directory for `prebuild-command`. |
+| `use-head-commit` | `false` | Check out the PR head SHA instead of the merge commit. |
+| `is-workspace` | `false` | Enable multi-package workspace mode. |
+| `workspace-packages` | _(none)_ | Comma-separated package directories (workspace mode). |
+| `workspace-prebuild-command` | _(none)_ | Command run once at the workspace root before counting. |
+| `fail-on-increase` | `true` | Fail the workflow when the error count increases. Set `false` to report only. |
 
 ## Outputs
 
-The main action provides the following outputs:
+| Output | Description |
+| --- | --- |
+| `head-errors` | Total strict errors on HEAD. |
+| `base-errors` | Total strict errors on BASE. |
+| `error-difference` | `head - base`. |
+| `errors-increased` | `true` / `false`. |
 
-- `head-errors`: Number of TypeScript errors in HEAD
-- `base-errors`: Number of TypeScript errors in BASE
-- `error-difference`: Difference in error count (HEAD - BASE)
-- `errors-increased`: Whether the error count increased
+In workspace mode the `typescript` and `compare` sub-actions additionally expose `package-errors` and `package-differences` as JSON maps keyed by package directory.
+
+---
+
+## Composite sub-actions
+
+`ts-stricter` is built from three composable actions you can also use on their own:
+
+| Action | Purpose |
+| --- | --- |
+| `thinkdx/ts-stricter/install@v2` | Set up Node + the package manager and install deps (with caching). |
+| `thinkdx/ts-stricter/typescript@v2` | Run `tsc` and output the error count (single package or workspace). |
+| `thinkdx/ts-stricter/compare@v2` | Compare two counts (or two per-package maps) and fail on increase. |
+
+The heavy lifting lives in plain shell scripts under [`scripts/`](./scripts), which the actions invoke — so the logic is unit-testable without GitHub (see below).
+
+---
+
+## Local development & testing
+
+The error-counting and comparison logic is covered by a fast local harness — no GitHub, no PR required:
+
+```bash
+./test/run-tests.sh
+```
+
+It runs against fixture projects (a single package and a multi-`tsconfig` workspace) and asserts strict enforcement, workspace counting, and every comparison outcome. See [`test/README.md`](./test/README.md) for details and how to add fixtures. The same suite runs in CI on Node 18/20/22.
+
+---
 
 ## Notes
 
-1. **Pull Request Context**: This Action is specifically designed for **pull_request** events because it compares HEAD vs. BASE.
-2. **TypeScript Configuration**: The action will use your repository's `tsconfig.json` by default, with the `--strict` flag enforced unless disabled.
-3. **Caching**: Dependency caching is enabled by default to speed up workflows. Disable it with `cache-dependencies: false` if needed.
-4. **Custom Commands**: Use `install-command` and `prebuild-command` to customize the workflow for complex setups.
+- **Pull-request events only.** The action compares HEAD vs BASE, so it expects a `pull_request` trigger.
+- **Custom Node/setup steps** belong _before_ this action if you need them.
+- **`tsconfig` must exist** where the action runs; otherwise `tsc` falls back to its defaults.
 
 ## Contributing
 
-Contributions and feedback are welcome! If you have new ideas or run into issues, please open a GitHub issue or submit a pull request to this repository.
+Issues and PRs welcome. If you change the scripts, run `./test/run-tests.sh` and add a fixture/assertion for the behavior.
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE). Feel free to modify and reuse in your own projects.
+[MIT](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,10 @@ inputs:
     required: false
   workspace-prebuild-command:
     description: Optional command to run before TypeScript compilation (runs at workspace root)
+  fail-on-increase:
+    description: Whether to fail the workflow when the error count increases
+    required: false
+    default: 'true'
 
 outputs:
   head-errors:
@@ -76,7 +80,7 @@ runs:
         ref: ${{ github.event.pull_request.base.sha }}
         
     - name: Install dependencies (BASE)
-      uses: thinkdx/ts-stricter/install@next
+      uses: thinkdx/ts-stricter/install@v2
       with:
         package-manager: ${{ inputs.package-manager }}
         working-directory: ${{ inputs.working-directory }}
@@ -87,7 +91,7 @@ runs:
 
     - name: Run TypeScript check (BASE)
       id: base-check
-      uses: thinkdx/ts-stricter/typescript@next
+      uses: thinkdx/ts-stricter/typescript@v2
       with:
         working-directory: ${{ inputs.working-directory }}
         tsconfig: ${{ inputs.tsconfig }}
@@ -111,7 +115,7 @@ runs:
         ref: ${{ github.event.pull_request.head.sha }}
         
     - name: Install dependencies (HEAD)
-      uses: thinkdx/ts-stricter/install@next
+      uses: thinkdx/ts-stricter/install@v2
       with:
         package-manager: ${{ inputs.package-manager }}
         working-directory: ${{ inputs.working-directory }}
@@ -122,7 +126,7 @@ runs:
 
     - name: Run TypeScript check (HEAD)
       id: head-check
-      uses: thinkdx/ts-stricter/typescript@next
+      uses: thinkdx/ts-stricter/typescript@v2
       with:
         working-directory: ${{ inputs.working-directory }}
         tsconfig: ${{ inputs.tsconfig }}
@@ -135,10 +139,11 @@ runs:
 
     - name: Compare error counts
       id: compare
-      uses: thinkdx/ts-stricter/compare@next
+      uses: thinkdx/ts-stricter/compare@v2
       with:
         head-errors: ${{ steps.head-check.outputs.error-count }}
         base-errors: ${{ steps.base-check.outputs.error-count }}
         head-package-errors: ${{ steps.head-check.outputs.package-errors }}
         base-package-errors: ${{ steps.base-check.outputs.package-errors }}
         is-workspace: ${{ inputs.is-workspace }}
+        fail-on-increase: ${{ inputs.fail-on-increase }}

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
     default: 'true'
   prebuild-command:
-    description: Optional command to run before TypeScript compilation
+    description: Optional command to run before TypeScript compilation (runs per package)
     required: false
   prebuild-working-directory:
     description: Working directory for prebuild command
@@ -43,6 +43,15 @@ inputs:
     description: Whether to use the head commit SHA instead of the merge SHA
     required: false
     default: 'false'
+  is-workspace:
+    description: Whether this is a workspace with multiple packages
+    required: false
+    default: 'false'
+  workspace-packages:
+    description: Comma-separated list of workspace package directories (only used if is-workspace is true)
+    required: false
+  workspace-prebuild-command:
+    description: Optional command to run before TypeScript compilation (runs at workspace root)
 
 outputs:
   head-errors:
@@ -85,6 +94,9 @@ runs:
         strict-override: ${{ inputs.strict-override }}
         prebuild-command: ${{ inputs.prebuild-command }}
         prebuild-working-directory: ${{ inputs.prebuild-working-directory }}
+        is-workspace: ${{ inputs.is-workspace }}
+        workspace-packages: ${{ inputs.workspace-packages }}
+        workspace-prebuild-command: ${{ inputs.workspace-prebuild-command }}
 
     - name: Check out HEAD (merged)
       if: ${{ inputs.use-head-commit == 'false' }}
@@ -117,6 +129,9 @@ runs:
         strict-override: ${{ inputs.strict-override }}
         prebuild-command: ${{ inputs.prebuild-command }}
         prebuild-working-directory: ${{ inputs.prebuild-working-directory }}
+        is-workspace: ${{ inputs.is-workspace }}
+        workspace-packages: ${{ inputs.workspace-packages }}
+        workspace-prebuild-command: ${{ inputs.workspace-prebuild-command }}
 
     - name: Compare error counts
       id: compare
@@ -124,3 +139,6 @@ runs:
       with:
         head-errors: ${{ steps.head-check.outputs.error-count }}
         base-errors: ${{ steps.base-check.outputs.error-count }}
+        head-package-errors: ${{ steps.head-check.outputs.package-errors }}
+        base-package-errors: ${{ steps.base-check.outputs.package-errors }}
+        is-workspace: ${{ inputs.is-workspace }}

--- a/compare/action.yml
+++ b/compare/action.yml
@@ -1,5 +1,5 @@
 name: Compare Error Counts
-description: Compare TypeScript error counts between two values
+description: Compare TypeScript error counts between two values and fail when they increase
 author: ThinkDX
 
 inputs:
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: 'false'
   fail-on-increase:
-    description: Whether to fail if HEAD has more errors than BASE
+    description: Whether to fail the action if HEAD has more errors than BASE
     required: false
     default: 'true'
 
@@ -41,96 +41,11 @@ runs:
     - name: Compare error counts
       id: compare
       shell: bash
-      run: |
-        if [ "${{ inputs.is-workspace }}" = "true" ]; then
-          # Handle workspace case
-          HEAD_ERRORS="${{ inputs.head-package-errors }}"
-          BASE_ERRORS="${{ inputs.base-package-errors }}"
-          FAIL_ON_INCREASE="${{ inputs.fail-on-increase }}"
-          
-          # Parse JSON objects into associative arrays
-          declare -A HEAD_COUNTS
-          declare -A BASE_COUNTS
-          declare -A DIFFERENCES
-          
-          # Extract package names and error counts from JSON
-          while IFS= read -r package; do
-            if [ -n "$package" ]; then
-              head_count=$(echo "$HEAD_ERRORS" | jq -r ".$package")
-              base_count=$(echo "$BASE_ERRORS" | jq -r ".$package")
-              HEAD_COUNTS["$package"]=$head_count
-              BASE_COUNTS["$package"]=$base_count
-              DIFFERENCES["$package"]=$((head_count - base_count))
-            fi
-          done < <(echo "$HEAD_ERRORS" | jq -r 'keys[]')
-          
-          # Calculate total difference
-          TOTAL_DIFF=0
-          for diff in "${DIFFERENCES[@]}"; do
-            TOTAL_DIFF=$((TOTAL_DIFF + diff))
-          done
-          
-          # Check if any package had an increase
-          ANY_INCREASE=false
-          for package in "${!DIFFERENCES[@]}"; do
-            if [ "${DIFFERENCES[$package]}" -gt 0 ]; then
-              ANY_INCREASE=true
-              echo "TypeScript errors increased in $package by ${DIFFERENCES[$package]}"
-              echo "HEAD Errors: ${HEAD_COUNTS[$package]}"
-              echo "BASE Errors: ${BASE_COUNTS[$package]}"
-            fi
-          done
-          
-          # Output results
-          echo "difference=$TOTAL_DIFF" >> $GITHUB_OUTPUT
-          echo "increased=$ANY_INCREASE" >> $GITHUB_OUTPUT
-          
-          # Convert differences to JSON
-          JSON="{"
-          for package in "${!DIFFERENCES[@]}"; do
-            if [ "$JSON" != "{" ]; then
-              JSON="$JSON,"
-            fi
-            JSON="$JSON\"$package\":${DIFFERENCES[$package]}"
-          done
-          JSON="$JSON}"
-          echo "package_differences=$JSON" >> $GITHUB_OUTPUT
-          
-          # Fail if any package had an increase and fail-on-increase is true
-          if [ "$ANY_INCREASE" = "true" ] && [ "$FAIL_ON_INCREASE" = "true" ]; then
-            echo "Error count increased in one or more packages. Failing..."
-            exit 1
-          fi
-        else
-          # Handle single package case
-          HEAD_ERRORS="${{ inputs.head-errors }}"
-          BASE_ERRORS="${{ inputs.base-errors }}"
-          FAIL_ON_INCREASE="${{ inputs.fail-on-increase }}"
-          
-          # Calculate difference
-          DIFFERENCE=$((HEAD_ERRORS - BASE_ERRORS))
-          echo "difference=$DIFFERENCE" >> $GITHUB_OUTPUT
-          
-          # Check if errors increased
-          if [ "$DIFFERENCE" -gt 0 ]; then
-            echo "increased=true" >> $GITHUB_OUTPUT
-            echo "TypeScript errors increased by $DIFFERENCE"
-            echo "HEAD Errors: $HEAD_ERRORS"
-            echo "BASE Errors: $BASE_ERRORS"
-            
-            if [ "$FAIL_ON_INCREASE" = "true" ]; then
-              echo "Error count increase ($DIFFERENCE). Failing..."
-              exit 1
-            fi
-          else
-            echo "increased=false" >> $GITHUB_OUTPUT
-            echo "TypeScript errors did not increase"
-            echo "HEAD Errors: $HEAD_ERRORS"
-            echo "BASE Errors: $BASE_ERRORS"
-            if [ "$DIFFERENCE" -lt 0 ]; then
-              echo "Reduced TypeScript errors by $((-DIFFERENCE))!"
-            else
-              echo "No change in error count"
-            fi
-          fi
-        fi 
+      env:
+        IS_WORKSPACE: ${{ inputs.is-workspace }}
+        FAIL_ON_INCREASE: ${{ inputs.fail-on-increase }}
+        HEAD_ERRORS: ${{ inputs.head-errors }}
+        BASE_ERRORS: ${{ inputs.base-errors }}
+        HEAD_PACKAGE_ERRORS: ${{ inputs.head-package-errors }}
+        BASE_PACKAGE_ERRORS: ${{ inputs.base-package-errors }}
+      run: bash "${{ github.action_path }}/../scripts/compare.sh"

--- a/compare/action.yml
+++ b/compare/action.yml
@@ -4,11 +4,21 @@ author: ThinkDX
 
 inputs:
   head-errors:
-    description: Number of errors in the HEAD branch
-    required: true
+    description: Number of errors in the HEAD branch (for single package)
+    required: false
   base-errors:
-    description: Number of errors in the BASE branch
-    required: true
+    description: Number of errors in the BASE branch (for single package)
+    required: false
+  head-package-errors:
+    description: JSON object containing error counts per package in HEAD (for workspaces)
+    required: false
+  base-package-errors:
+    description: JSON object containing error counts per package in BASE (for workspaces)
+    required: false
+  is-workspace:
+    description: Whether this is a workspace with multiple packages
+    required: false
+    default: 'false'
   fail-on-increase:
     description: Whether to fail if HEAD has more errors than BASE
     required: false
@@ -21,6 +31,9 @@ outputs:
   difference:
     description: The difference in error count (HEAD - BASE)
     value: ${{ steps.compare.outputs.difference }}
+  package-differences:
+    description: JSON object containing differences per package (for workspaces)
+    value: ${{ steps.compare.outputs.package_differences }}
 
 runs:
   using: "composite"
@@ -29,33 +42,95 @@ runs:
       id: compare
       shell: bash
       run: |
-        HEAD_ERRORS="${{ inputs.head-errors }}"
-        BASE_ERRORS="${{ inputs.base-errors }}"
-        FAIL_ON_INCREASE="${{ inputs.fail-on-increase }}"
-        
-        # Calculate difference
-        DIFFERENCE=$((HEAD_ERRORS - BASE_ERRORS))
-        echo "difference=$DIFFERENCE" >> $GITHUB_OUTPUT
-        
-        # Check if errors increased
-        if [ "$DIFFERENCE" -gt 0 ]; then
-          echo "increased=true" >> $GITHUB_OUTPUT
-          echo "TypeScript errors increased by $DIFFERENCE"
-          echo "HEAD Errors: $HEAD_ERRORS"
-          echo "BASE Errors: $BASE_ERRORS"
+        if [ "${{ inputs.is-workspace }}" = "true" ]; then
+          # Handle workspace case
+          HEAD_ERRORS="${{ inputs.head-package-errors }}"
+          BASE_ERRORS="${{ inputs.base-package-errors }}"
+          FAIL_ON_INCREASE="${{ inputs.fail-on-increase }}"
           
-          if [ "$FAIL_ON_INCREASE" = "true" ]; then
-            echo "Error count increase ($DIFFERENCE). Failing..."
+          # Parse JSON objects into associative arrays
+          declare -A HEAD_COUNTS
+          declare -A BASE_COUNTS
+          declare -A DIFFERENCES
+          
+          # Extract package names and error counts from JSON
+          while IFS= read -r package; do
+            if [ -n "$package" ]; then
+              head_count=$(echo "$HEAD_ERRORS" | jq -r ".$package")
+              base_count=$(echo "$BASE_ERRORS" | jq -r ".$package")
+              HEAD_COUNTS["$package"]=$head_count
+              BASE_COUNTS["$package"]=$base_count
+              DIFFERENCES["$package"]=$((head_count - base_count))
+            fi
+          done < <(echo "$HEAD_ERRORS" | jq -r 'keys[]')
+          
+          # Calculate total difference
+          TOTAL_DIFF=0
+          for diff in "${DIFFERENCES[@]}"; do
+            TOTAL_DIFF=$((TOTAL_DIFF + diff))
+          done
+          
+          # Check if any package had an increase
+          ANY_INCREASE=false
+          for package in "${!DIFFERENCES[@]}"; do
+            if [ "${DIFFERENCES[$package]}" -gt 0 ]; then
+              ANY_INCREASE=true
+              echo "TypeScript errors increased in $package by ${DIFFERENCES[$package]}"
+              echo "HEAD Errors: ${HEAD_COUNTS[$package]}"
+              echo "BASE Errors: ${BASE_COUNTS[$package]}"
+            fi
+          done
+          
+          # Output results
+          echo "difference=$TOTAL_DIFF" >> $GITHUB_OUTPUT
+          echo "increased=$ANY_INCREASE" >> $GITHUB_OUTPUT
+          
+          # Convert differences to JSON
+          JSON="{"
+          for package in "${!DIFFERENCES[@]}"; do
+            if [ "$JSON" != "{" ]; then
+              JSON="$JSON,"
+            fi
+            JSON="$JSON\"$package\":${DIFFERENCES[$package]}"
+          done
+          JSON="$JSON}"
+          echo "package_differences=$JSON" >> $GITHUB_OUTPUT
+          
+          # Fail if any package had an increase and fail-on-increase is true
+          if [ "$ANY_INCREASE" = "true" ] && [ "$FAIL_ON_INCREASE" = "true" ]; then
+            echo "Error count increased in one or more packages. Failing..."
             exit 1
           fi
         else
-          echo "increased=false" >> $GITHUB_OUTPUT
-          echo "TypeScript errors did not increase"
-          echo "HEAD Errors: $HEAD_ERRORS"
-          echo "BASE Errors: $BASE_ERRORS"
-          if [ "$DIFFERENCE" -lt 0 ]; then
-            echo "Reduced TypeScript errors by $((-DIFFERENCE))!"
+          # Handle single package case
+          HEAD_ERRORS="${{ inputs.head-errors }}"
+          BASE_ERRORS="${{ inputs.base-errors }}"
+          FAIL_ON_INCREASE="${{ inputs.fail-on-increase }}"
+          
+          # Calculate difference
+          DIFFERENCE=$((HEAD_ERRORS - BASE_ERRORS))
+          echo "difference=$DIFFERENCE" >> $GITHUB_OUTPUT
+          
+          # Check if errors increased
+          if [ "$DIFFERENCE" -gt 0 ]; then
+            echo "increased=true" >> $GITHUB_OUTPUT
+            echo "TypeScript errors increased by $DIFFERENCE"
+            echo "HEAD Errors: $HEAD_ERRORS"
+            echo "BASE Errors: $BASE_ERRORS"
+            
+            if [ "$FAIL_ON_INCREASE" = "true" ]; then
+              echo "Error count increase ($DIFFERENCE). Failing..."
+              exit 1
+            fi
           else
-            echo "No change in error count"
+            echo "increased=false" >> $GITHUB_OUTPUT
+            echo "TypeScript errors did not increase"
+            echo "HEAD Errors: $HEAD_ERRORS"
+            echo "BASE Errors: $BASE_ERRORS"
+            if [ "$DIFFERENCE" -lt 0 ]; then
+              echo "Reduced TypeScript errors by $((-DIFFERENCE))!"
+            else
+              echo "No change in error count"
+            fi
           fi
         fi 

--- a/install/action.yml
+++ b/install/action.yml
@@ -28,13 +28,19 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # pnpm must be on PATH *before* setup-node, otherwise `cache: pnpm` fails
+    # because setup-node can't locate the pnpm store.
+    - name: Install pnpm
+      if: ${{ inputs.package-manager == 'pnpm' }}
+      uses: pnpm/action-setup@v4
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
         cache: ${{ (inputs.cache-dependencies == 'true' && inputs.package-manager) || '' }}
-        
+
     - name: Get package manager data
       id: package-manager
       shell: bash
@@ -50,10 +56,6 @@ runs:
             echo "install_cmd=pnpm install --frozen-lockfile" >> $GITHUB_OUTPUT
             ;;
         esac
-
-    - name: Install pnpm
-      if: ${{ inputs.package-manager == 'pnpm' }}
-      uses: pnpm/action-setup@v4
 
     - name: Install dependencies
       shell: bash

--- a/scripts/compare.sh
+++ b/scripts/compare.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Compare HEAD vs BASE TypeScript error counts and fail when errors increase.
+#
+# Reads (env):
+#   IS_WORKSPACE          - "true" to compare per-package JSON maps
+#   FAIL_ON_INCREASE      - "true" (default) to exit 1 on any increase
+#   GITHUB_OUTPUT         - optional; results appended as key=value
+#
+#   Single package:
+#     HEAD_ERRORS, BASE_ERRORS              - integers
+#   Workspace:
+#     HEAD_PACKAGE_ERRORS, BASE_PACKAGE_ERRORS - JSON {dir: count}
+#
+# Writes:  difference=<int>  increased=<true|false>
+#          package_differences=<json>   (workspace only)
+#
+# Exit code: 1 when errors increased and FAIL_ON_INCREASE=true, else 0.
+
+set -euo pipefail
+
+fail_on_increase="${FAIL_ON_INCREASE:-true}"
+is_workspace="${IS_WORKSPACE:-false}"
+
+emit() {
+  local line="$1"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s\n' "$line" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+if [ "$is_workspace" = "true" ]; then
+  # Note: `${VAR:-{}}` does NOT default to "{}" — bash parses it as
+  # `${VAR:-{}` followed by a literal "}", corrupting valid JSON. Default
+  # explicitly instead.
+  head_json="${HEAD_PACKAGE_ERRORS:-}"; [ -z "$head_json" ] && head_json='{}'
+  base_json="${BASE_PACKAGE_ERRORS:-}"; [ -z "$base_json" ] && base_json='{}'
+
+  # Per-package diff over the union of package names. Missing on either side
+  # is treated as 0. Using jq with the keys as data (not interpolated into the
+  # filter) keeps directory names containing "/" working correctly.
+  diffs_json="$(jq -cn \
+    --argjson head "$head_json" \
+    --argjson base "$base_json" \
+    '[$head, $base] | add | keys
+       | map({ (.): (($head[.] // 0) - ($base[.] // 0)) })
+       | add // {}')"
+
+  total_diff="$(jq -n --argjson d "$diffs_json" '[$d[]] | add // 0')"
+  increased="$(jq -rn --argjson d "$diffs_json" 'if [$d[]] | any(. > 0) then "true" else "false" end')"
+
+  # Human-readable per-package report.
+  while IFS= read -r line; do
+    echo "$line"
+  done < <(jq -rn \
+    --argjson head "$head_json" \
+    --argjson base "$base_json" \
+    --argjson d "$diffs_json" \
+    '$d | to_entries[]
+       | "  \(.key): \($head[.key] // 0) (head) vs \($base[.key] // 0) (base) => " +
+         (if .value > 0 then "+\(.value) ❌"
+          elif .value < 0 then "\(.value) ✅"
+          else "no change" end)')
+
+  emit "difference=$total_diff"
+  emit "increased=$increased"
+  emit "package_differences=$diffs_json"
+
+  if [ "$increased" = "true" ]; then
+    echo "❌ TypeScript error count increased in one or more packages (total +$total_diff)."
+    if [ "$fail_on_increase" = "true" ]; then exit 1; fi
+  else
+    echo "✅ TypeScript error count did not increase (total change: $total_diff)."
+  fi
+else
+  head_errors="${HEAD_ERRORS:-0}"
+  base_errors="${BASE_ERRORS:-0}"
+  difference=$(( head_errors - base_errors ))
+
+  emit "difference=$difference"
+  echo "HEAD errors: $head_errors"
+  echo "BASE errors: $base_errors"
+
+  if [ "$difference" -gt 0 ]; then
+    emit "increased=true"
+    echo "❌ TypeScript error count increased by $difference (from $base_errors to $head_errors)."
+    if [ "$fail_on_increase" = "true" ]; then exit 1; fi
+  else
+    emit "increased=false"
+    if [ "$difference" -lt 0 ]; then
+      echo "✅ Reduced TypeScript errors by $(( -difference ))! ($base_errors -> $head_errors)"
+    else
+      echo "✅ No change in TypeScript error count ($head_errors)."
+    fi
+  fi
+fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for ts-stricter.
+#
+# This file is meant to be *sourced*, not executed. It contains the core
+# TypeScript-error-counting logic so it can be unit-tested directly (see
+# test/run-tests.sh) instead of being trapped inside action YAML.
+#
+# Configuration is read from the environment so the same code works both
+# inside a GitHub composite action and from the local test runner:
+#
+#   TSCONFIG          Path to tsconfig, relative to the package directory.
+#                     Default: "tsconfig.json".
+#   STRICT_OVERRIDE   "true" to force `--strict` on the compiler regardless
+#                     of what the tsconfig says. Default: "true".
+#   TSC_CMD           Override the compiler binary invocation (mainly for
+#                     tests). Default: "npx tsc".
+
+set -euo pipefail
+
+# Parse a tsc error count out of compiler output.
+#
+# tsc prints a trailing summary line in a few shapes:
+#   "Found 1 error in foo.ts:3"
+#   "Found 12 errors in 4 files."
+#   "Found 12 errors in the same file, starting at: foo.ts:3"
+# A clean run prints no such line, in which case the count is 0.
+ts_stricter::parse_count() {
+  local output="$1"
+  local count
+  count=$(printf '%s\n' "$output" \
+    | grep -Eo 'Found ([0-9]+) error' \
+    | grep -Eo '[0-9]+' \
+    | head -n1 || true)
+  printf '%s\n' "${count:-0}"
+}
+
+# Run tsc in a single directory and echo the integer error count.
+#
+# $1 - directory to run in (default ".").
+#
+# The tsconfig existence check and the compiler run happen in the *same*
+# directory, so a relative TSCONFIG always resolves consistently (this was a
+# bug in the original inline workspace implementation).
+ts_stricter::count_errors_in_dir() {
+  local dir="${1:-.}"
+  local tsconfig="${TSCONFIG:-tsconfig.json}"
+  local strict_override="${STRICT_OVERRIDE:-true}"
+  local tsc_cmd="${TSC_CMD:-npx tsc}"
+
+  (
+    cd "$dir" || exit 1
+
+    local cmd="$tsc_cmd --pretty --noEmit"
+    if [ "$strict_override" = "true" ]; then
+      cmd="$cmd --strict"
+    fi
+    if [ -f "$tsconfig" ]; then
+      cmd="$cmd --project $tsconfig"
+    fi
+
+    # tsc exits non-zero when it finds errors; that is expected, so never let
+    # it abort the script. We only care about the parsed count.
+    local output
+    output=$(eval "$cmd" 2>&1 || true)
+    ts_stricter::parse_count "$output"
+  )
+}
+
+# Trim leading/trailing whitespace from a string.
+ts_stricter::trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}

--- a/scripts/run-check.sh
+++ b/scripts/run-check.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Run the TypeScript error count for a single package or a whole workspace.
+#
+# Reads (env):
+#   TSCONFIG, STRICT_OVERRIDE   - see lib.sh
+#   IS_WORKSPACE                - "true" to run across WORKSPACE_PACKAGES
+#   WORKSPACE_PACKAGES          - comma-separated package directories
+#   GITHUB_OUTPUT               - optional; when set, results are appended in
+#                                 the `key=value` form GitHub Actions expects
+#
+# Writes (single package):    error_count=<int>
+# Writes (workspace):         package_errors=<json {dir: count}>
+#                             error_count=<int total across packages>
+#
+# `error_count` is emitted in *both* modes so the parent action's outputs are
+# never empty (workspace mode used to leave it unset).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+emit() {
+  local line="$1"
+  printf '%s\n' "$line"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s\n' "$line" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+is_workspace="${IS_WORKSPACE:-false}"
+
+if [ "$is_workspace" = "true" ]; then
+  if [ -z "${WORKSPACE_PACKAGES:-}" ]; then
+    echo "is-workspace is true but workspace-packages is empty." >&2
+    exit 1
+  fi
+
+  json='{}'
+  total=0
+  IFS=',' read -ra packages <<< "$WORKSPACE_PACKAGES"
+  for raw in "${packages[@]}"; do
+    pkg="$(ts_stricter::trim "$raw")"
+    [ -z "$pkg" ] && continue
+    count="$(ts_stricter::count_errors_in_dir "$pkg")"
+    echo "TypeScript errors in $pkg: $count"
+    json="$(jq -c --arg k "$pkg" --argjson v "$count" '. + {($k): $v}' <<< "$json")"
+    total=$(( total + count ))
+  done
+
+  emit "package_errors=$json"
+  emit "error_count=$total"
+else
+  count="$(ts_stricter::count_errors_in_dir ".")"
+  echo "TypeScript errors found: $count"
+  emit "error_count=$count"
+fi

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,49 @@
+# Test harness
+
+Fast, local tests for the logic that powers `ts-stricter` — error counting and
+HEAD-vs-BASE comparison — without needing GitHub or a real pull request.
+
+```bash
+./test/run-tests.sh
+```
+
+On first run it installs a single copy of TypeScript under `test/node_modules`
+(shared by every fixture), then exercises the scripts in `../scripts` against
+the fixtures below. It exits non-zero if any assertion fails. The same script
+runs in CI (`.github/workflows/test.yml`) across Node 18/20/22.
+
+## What it covers
+
+- **Strict enforcement** — the `single` fixture reports `0` errors with
+  `strict: false` and `2` under `--strict`, proving `strict-override` works.
+- **Workspaces / multiple tsconfigs** — the `workspace` fixture has two packages
+  (`packages/a`, `packages/b`), each with its own `tsconfig.json`, and asserts
+  the per-package JSON and the total.
+- **Comparison semantics** — no-change passes, an increase fails (exit 1),
+  a reduction passes, and `fail-on-increase: false` downgrades a failure.
+- **Slashed package names** — workspace comparison uses package paths like
+  `packages/a` as JSON keys (a case the original `jq` code got wrong).
+
+## Fixtures
+
+| Fixture                | Shape                          | Strict errors |
+| ---------------------- | ------------------------------ | ------------- |
+| `fixtures/single`      | one package                    | 2             |
+| `fixtures/workspace`   | `packages/a` + `packages/b`    | 2 + 1 = 3     |
+
+Each fixture sets `strict: false` in its `tsconfig.json` and contains code that
+only errors under strict mode, so the count is meaningfully different with and
+without enforcement.
+
+## Adding a fixture
+
+1. Create a directory under `fixtures/` with a `tsconfig.json` (`strict: false`,
+   `noEmit: true`, `skipLibCheck: true`) and some `.ts` source with a known
+   number of strict-only errors.
+2. Add assertions in `run-tests.sh` using the existing helpers
+   (`run_script`, `out`, `assert_eq`).
+
+The scripts read all configuration from environment variables (`TSCONFIG`,
+`STRICT_OVERRIDE`, `IS_WORKSPACE`, `WORKSPACE_PACKAGES`, `HEAD_ERRORS`, …) and
+`TSC_CMD` lets the harness point at the local TypeScript install, so no GitHub
+context is required.

--- a/test/fixtures/single/src/index.ts
+++ b/test/fixtures/single/src/index.ts
@@ -1,0 +1,12 @@
+// This fixture is clean with `strict: false` but produces exactly 2 errors
+// under `--strict`. The test runner asserts both counts, proving that
+// ts-stricter's strict enforcement actually changes what tsc reports.
+
+// 1) noImplicitAny: parameter `name` implicitly has type `any`.
+export function greet(name) {
+  return `Hello, ${name.toUpperCase()}`;
+}
+
+// 2) strictNullChecks: `value` is possibly null.
+const value: string | null = (Math.random() > 0.5 ? "x" : null) as string | null;
+export const length = value.length;

--- a/test/fixtures/single/tsconfig.json
+++ b/test/fixtures/single/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "strict": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src"]
+}

--- a/test/fixtures/workspace/packages/a/src/index.ts
+++ b/test/fixtures/workspace/packages/a/src/index.ts
@@ -1,0 +1,10 @@
+// Package "a": 2 strict-mode errors, clean under strict: false.
+
+// noImplicitAny
+export function double(x) {
+  return x * 2;
+}
+
+// strictNullChecks
+const maybe: number | null = (Math.random() > 0.5 ? 1 : null) as number | null;
+export const next = maybe + 1;

--- a/test/fixtures/workspace/packages/a/tsconfig.json
+++ b/test/fixtures/workspace/packages/a/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "strict": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src"]
+}

--- a/test/fixtures/workspace/packages/b/src/index.ts
+++ b/test/fixtures/workspace/packages/b/src/index.ts
@@ -1,0 +1,6 @@
+// Package "b": 1 strict-mode error, clean under strict: false.
+
+// noImplicitAny
+export function identity(value) {
+  return value;
+}

--- a/test/fixtures/workspace/packages/b/tsconfig.json
+++ b/test/fixtures/workspace/packages/b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "strict": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src"]
+}

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "ts-stricter-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ts-stricter-tests",
+      "devDependencies": {
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ts-stricter-tests",
+  "private": true,
+  "description": "Local test harness for ts-stricter. Provides a single typescript install shared by all fixtures.",
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Local test harness for ts-stricter.
+#
+# Exercises the extracted scripts (scripts/lib.sh, run-check.sh, compare.sh)
+# against the fixture projects under test/fixtures/ — no GitHub, no network
+# beyond a one-time `npm install` of TypeScript.
+#
+#   ./test/run-tests.sh
+#
+# Exits non-zero if any assertion fails.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$TEST_DIR/.." && pwd)"
+SCRIPTS="$REPO_DIR/scripts"
+FIXTURES="$TEST_DIR/fixtures"
+
+PASS=0
+FAIL=0
+
+green() { printf '\033[32m%s\033[0m' "$1"; }
+red()   { printf '\033[31m%s\033[0m' "$1"; }
+
+ok()  { PASS=$((PASS + 1)); printf '  %s %s\n' "$(green '✓')" "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  %s %s\n' "$(red '✗')" "$1"; }
+
+# assert_eq <description> <expected> <actual>
+assert_eq() {
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+
+# Run a script with a scratch GITHUB_OUTPUT file. Inline assignment exports
+# GITHUB_OUTPUT to the (external) script. Any other env the script needs must
+# already be exported by the caller. Results:
+#   $RUN_RC      exit code
+#   out <key>    value emitted for <key>
+RUN_OUT=""
+RUN_RC=0
+run_script() {
+  RUN_OUT="$(mktemp)"
+  GITHUB_OUTPUT="$RUN_OUT" "$@"
+  RUN_RC=$?
+}
+out() { grep -E "^$1=" "$RUN_OUT" | head -n1 | cut -d= -f2-; }
+
+# ---------------------------------------------------------------------------
+# Setup: one shared TypeScript install used by every fixture.
+# ---------------------------------------------------------------------------
+if [ ! -x "$TEST_DIR/node_modules/.bin/tsc" ]; then
+  echo "Installing TypeScript for the test harness..."
+  (cd "$TEST_DIR" && npm install --no-audit --no-fund --silent)
+fi
+export TSC_CMD="$TEST_DIR/node_modules/.bin/tsc"
+echo "Using $($TSC_CMD --version)"
+echo
+
+# ===========================================================================
+echo "▸ count: single package, strict OFF (should be clean)"
+export STRICT_OVERRIDE=false IS_WORKSPACE=false
+pushd "$FIXTURES/single" >/dev/null; run_script "$SCRIPTS/run-check.sh"; popd >/dev/null
+assert_eq "single, strict off → 0 errors" "0" "$(out error_count)"
+
+echo "▸ count: single package, strict ON"
+export STRICT_OVERRIDE=true
+pushd "$FIXTURES/single" >/dev/null; run_script "$SCRIPTS/run-check.sh"; popd >/dev/null
+assert_eq "single, strict on → 2 errors" "2" "$(out error_count)"
+
+echo "▸ count: workspace, multiple tsconfigs, strict ON"
+export STRICT_OVERRIDE=true IS_WORKSPACE=true WORKSPACE_PACKAGES="packages/a, packages/b"
+pushd "$FIXTURES/workspace" >/dev/null; run_script "$SCRIPTS/run-check.sh"; popd >/dev/null
+assert_eq "workspace → package_errors json" '{"packages/a":2,"packages/b":1}' "$(out package_errors)"
+assert_eq "workspace → total error_count" "3" "$(out error_count)"
+unset STRICT_OVERRIDE IS_WORKSPACE WORKSPACE_PACKAGES
+
+# ===========================================================================
+echo "▸ compare: single, no change"
+export HEAD_ERRORS=5 BASE_ERRORS=5; run_script "$SCRIPTS/compare.sh"
+assert_eq "no change → rc 0" "0" "$RUN_RC"
+assert_eq "no change → increased=false" "false" "$(out increased)"
+assert_eq "no change → difference=0" "0" "$(out difference)"
+
+echo "▸ compare: single, errors increased (should fail)"
+export HEAD_ERRORS=7 BASE_ERRORS=5; run_script "$SCRIPTS/compare.sh"
+assert_eq "increase → rc 1" "1" "$RUN_RC"
+assert_eq "increase → increased=true" "true" "$(out increased)"
+assert_eq "increase → difference=2" "2" "$(out difference)"
+
+echo "▸ compare: single, errors reduced (should pass)"
+export HEAD_ERRORS=3 BASE_ERRORS=5; run_script "$SCRIPTS/compare.sh"
+assert_eq "reduced → rc 0" "0" "$RUN_RC"
+assert_eq "reduced → increased=false" "false" "$(out increased)"
+assert_eq "reduced → difference=-2" "-2" "$(out difference)"
+
+echo "▸ compare: single, increase but fail-on-increase=false"
+export HEAD_ERRORS=7 BASE_ERRORS=5 FAIL_ON_INCREASE=false; run_script "$SCRIPTS/compare.sh"
+assert_eq "soft increase → rc 0" "0" "$RUN_RC"
+assert_eq "soft increase → increased=true" "true" "$(out increased)"
+unset HEAD_ERRORS BASE_ERRORS FAIL_ON_INCREASE
+
+# ===========================================================================
+export IS_WORKSPACE=true
+echo "▸ compare: workspace, slashed package names, one package regresses"
+export HEAD_PACKAGE_ERRORS='{"packages/a":3,"packages/b":1}'
+export BASE_PACKAGE_ERRORS='{"packages/a":2,"packages/b":1}'
+run_script "$SCRIPTS/compare.sh"
+assert_eq "ws regress → rc 1" "1" "$RUN_RC"
+assert_eq "ws regress → increased=true" "true" "$(out increased)"
+assert_eq "ws regress → difference=1" "1" "$(out difference)"
+assert_eq "ws regress → package_differences" '{"packages/a":1,"packages/b":0}' "$(out package_differences)"
+
+echo "▸ compare: workspace, net reduction across packages"
+export HEAD_PACKAGE_ERRORS='{"packages/a":0,"packages/b":1}'
+export BASE_PACKAGE_ERRORS='{"packages/a":2,"packages/b":1}'
+run_script "$SCRIPTS/compare.sh"
+assert_eq "ws reduce → rc 0" "0" "$RUN_RC"
+assert_eq "ws reduce → increased=false" "false" "$(out increased)"
+assert_eq "ws reduce → difference=-2" "-2" "$(out difference)"
+
+echo "▸ compare: workspace, a brand-new package with errors regresses"
+export HEAD_PACKAGE_ERRORS='{"packages/a":2,"packages/c":4}'
+export BASE_PACKAGE_ERRORS='{"packages/a":2}'
+run_script "$SCRIPTS/compare.sh"
+assert_eq "ws new pkg → rc 1" "1" "$RUN_RC"
+assert_eq "ws new pkg → difference=4" "4" "$(out difference)"
+unset IS_WORKSPACE HEAD_PACKAGE_ERRORS BASE_PACKAGE_ERRORS
+
+# ===========================================================================
+echo
+if [ "$FAIL" -eq 0 ]; then
+  printf '%s\n' "$(green "All $PASS checks passed.")"
+  exit 0
+else
+  printf '%s\n' "$(red "$FAIL failed, $PASS passed.")"
+  exit 1
+fi

--- a/typescript/action.yml
+++ b/typescript/action.yml
@@ -22,15 +22,34 @@ inputs:
     description: Working directory for prebuild command
     required: false
     default: '.'
+  is-workspace:
+    description: Whether this is a workspace with multiple packages
+    required: false
+    default: 'false'
+  workspace-packages:
+    description: Comma-separated list of workspace package directories
+    required: false
+  workspace-prebuild-command:
+    description: Optional command to run before TypeScript compilation at workspace root
+    required: false
 
 outputs:
   error-count:
-    description: The number of TypeScript errors found
+    description: The number of TypeScript errors found (for single package)
     value: ${{ steps.count-errors.outputs.error_count }}
+  package-errors:
+    description: JSON object containing error counts per package (for workspaces)
+    value: ${{ steps.count-errors.outputs.package_errors }}
 
 runs:
   using: "composite"
   steps:
+    - name: Run workspace prebuild command
+      if: inputs.is-workspace == 'true' && inputs.workspace-prebuild-command != ''
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: ${{ inputs.workspace-prebuild-command }}
+
     - name: Run prebuild command
       if: inputs.prebuild-command != ''
       shell: bash
@@ -44,6 +63,7 @@ runs:
       run: |
         # Function to run TSC and get error count
         run_tsc_and_get_errors() {
+          local PACKAGE_DIR="$1"
           local OUTPUT
           local COUNT
           local CONFIG_PATH="${{ inputs.tsconfig }}"
@@ -63,7 +83,7 @@ runs:
           fi
 
           # Run TSC and capture output
-          OUTPUT=$($TSC_CMD 2>&1 || true)
+          OUTPUT=$(cd "$PACKAGE_DIR" && $TSC_CMD 2>&1 || true)
           
           # Parse error count using improved regex
           COUNT=$(echo "$OUTPUT" | grep -Eo "Found ([0-9]+) error(s?)" | grep -Eo "[0-9]+" | head -n1 || echo "0")
@@ -71,7 +91,32 @@ runs:
           echo "$COUNT"
         }
 
-        # Run TSC and get error count
-        ERROR_COUNT=$(run_tsc_and_get_errors)
-        echo "TypeScript errors found: $ERROR_COUNT"
-        echo "error_count=$ERROR_COUNT" >> $GITHUB_OUTPUT 
+        if [ "${{ inputs.is-workspace }}" = "true" ]; then
+          # Handle workspace case
+          declare -A PACKAGE_ERRORS
+          IFS=',' read -ra PACKAGES <<< "${{ inputs.workspace-packages }}"
+          
+          for PACKAGE in "${PACKAGES[@]}"; do
+            PACKAGE=$(echo "$PACKAGE" | xargs) # Trim whitespace
+            ERROR_COUNT=$(run_tsc_and_get_errors "$PACKAGE")
+            PACKAGE_ERRORS["$PACKAGE"]=$ERROR_COUNT
+            echo "TypeScript errors in $PACKAGE: $ERROR_COUNT"
+          done
+          
+          # Convert associative array to JSON
+          JSON="{"
+          for PACKAGE in "${!PACKAGE_ERRORS[@]}"; do
+            if [ "$JSON" != "{" ]; then
+              JSON="$JSON,"
+            fi
+            JSON="$JSON\"$PACKAGE\":${PACKAGE_ERRORS[$PACKAGE]}"
+          done
+          JSON="$JSON}"
+          
+          echo "package_errors=$JSON" >> $GITHUB_OUTPUT
+        else
+          # Handle single package case
+          ERROR_COUNT=$(run_tsc_and_get_errors ".")
+          echo "TypeScript errors found: $ERROR_COUNT"
+          echo "error_count=$ERROR_COUNT" >> $GITHUB_OUTPUT
+        fi 

--- a/typescript/action.yml
+++ b/typescript/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: false
     default: '.'
   tsconfig:
-    description: Path to custom tsconfig.json file (relative to working-directory)
+    description: Path to custom tsconfig.json file (relative to working-directory, or to each package in workspace mode)
     required: false
     default: 'tsconfig.json'
   strict-override:
@@ -35,7 +35,7 @@ inputs:
 
 outputs:
   error-count:
-    description: The number of TypeScript errors found (for single package)
+    description: The number of TypeScript errors found (total across packages in workspace mode)
     value: ${{ steps.count-errors.outputs.error_count }}
   package-errors:
     description: JSON object containing error counts per package (for workspaces)
@@ -60,63 +60,9 @@ runs:
       id: count-errors
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: |
-        # Function to run TSC and get error count
-        run_tsc_and_get_errors() {
-          local PACKAGE_DIR="$1"
-          local OUTPUT
-          local COUNT
-          local CONFIG_PATH="${{ inputs.tsconfig }}"
-          local STRICT_OVERRIDE="${{ inputs.strict-override }}"
-          
-          # Prepare TSC command
-          local TSC_CMD="npx tsc --pretty --noEmit"
-          
-          # Add strict override if enabled
-          if [ "$STRICT_OVERRIDE" = "true" ]; then
-            TSC_CMD="$TSC_CMD --strict"
-          fi
-          
-          # Add config path if specified
-          if [ -f "$CONFIG_PATH" ]; then
-            TSC_CMD="$TSC_CMD --project $CONFIG_PATH"
-          fi
-
-          # Run TSC and capture output
-          OUTPUT=$(cd "$PACKAGE_DIR" && $TSC_CMD 2>&1 || true)
-          
-          # Parse error count using improved regex
-          COUNT=$(echo "$OUTPUT" | grep -Eo "Found ([0-9]+) error(s?)" | grep -Eo "[0-9]+" | head -n1 || echo "0")
-          
-          echo "$COUNT"
-        }
-
-        if [ "${{ inputs.is-workspace }}" = "true" ]; then
-          # Handle workspace case
-          declare -A PACKAGE_ERRORS
-          IFS=',' read -ra PACKAGES <<< "${{ inputs.workspace-packages }}"
-          
-          for PACKAGE in "${PACKAGES[@]}"; do
-            PACKAGE=$(echo "$PACKAGE" | xargs) # Trim whitespace
-            ERROR_COUNT=$(run_tsc_and_get_errors "$PACKAGE")
-            PACKAGE_ERRORS["$PACKAGE"]=$ERROR_COUNT
-            echo "TypeScript errors in $PACKAGE: $ERROR_COUNT"
-          done
-          
-          # Convert associative array to JSON
-          JSON="{"
-          for PACKAGE in "${!PACKAGE_ERRORS[@]}"; do
-            if [ "$JSON" != "{" ]; then
-              JSON="$JSON,"
-            fi
-            JSON="$JSON\"$PACKAGE\":${PACKAGE_ERRORS[$PACKAGE]}"
-          done
-          JSON="$JSON}"
-          
-          echo "package_errors=$JSON" >> $GITHUB_OUTPUT
-        else
-          # Handle single package case
-          ERROR_COUNT=$(run_tsc_and_get_errors ".")
-          echo "TypeScript errors found: $ERROR_COUNT"
-          echo "error_count=$ERROR_COUNT" >> $GITHUB_OUTPUT
-        fi 
+      env:
+        TSCONFIG: ${{ inputs.tsconfig }}
+        STRICT_OVERRIDE: ${{ inputs.strict-override }}
+        IS_WORKSPACE: ${{ inputs.is-workspace }}
+        WORKSPACE_PACKAGES: ${{ inputs.workspace-packages }}
+      run: bash "${{ github.action_path }}/../scripts/run-check.sh"


### PR DESCRIPTION
Consolidates `v2-ws` onto `v2` (workspace support becomes a mode, not a branch), extracts the action logic into testable scripts, fixes several bugs, and overhauls the README.

## Why
The error-counting and comparison logic lived inline in YAML, so none of it was testable — which is how a handful of bugs slipped in. This moves the logic into `scripts/` and adds a local test harness, then fixes the bugs (each now covered by a test).

## Bug fixes
- **compare (workspaces):** per-package diff used `jq ".$package"`, which breaks for directory names containing `/` (e.g. `packages/a`). Now passes keys as data via `--arg`/`--argjson`.
- **install:** `pnpm/action-setup` now runs *before* `setup-node`, so `cache: pnpm` can find the store.
- **typescript:** the tsconfig existence check and the `tsc` run now happen in the same directory (was inconsistent in workspace mode).
- **typescript:** `error_count` is now emitted in workspace mode too, so the root action's `head-errors`/`base-errors` outputs aren't empty for workspaces.
- **root:** sub-action refs repointed `@next` → `@v2` to match the README.
- **compare:** `${VAR:-{}}` corrupted JSON (parses as `${VAR:-{}` + literal `}`); `fail-on-increase: false` no longer exits 1 on an increase. (Both caught by the new tests.)

## Additions
- `scripts/{lib,run-check,compare}.sh` — the extracted, env-driven logic.
- `test/run-tests.sh` + fixtures (single package, multi-`tsconfig` workspace). Runs in seconds, no GitHub needed. **24/24 checks pass.**
- `.github/workflows/test.yml` — runs the harness on Node 18/20/22.
- README rewritten around the recommended **strict-on-in-dev / off-in-build** workflow, with accurate inputs/outputs and a workspaces section.

## Not yet verified
Local tests cover the logic thoroughly but **not** the composite-action plumbing (the `@v2` sub-action refs, install step, pnpm). That needs a published `v2` tag or `act` — see the follow-up on end-to-end action testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)