### PR TITLE
Add pnpm-version input (graceful pnpm setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Per-package error counts and differences are exposed as JSON outputs (`package-e
 | --- | --- | --- |
 | `working-directory` | `.` | Directory to run TypeScript in. |
 | `package-manager` | `npm` | `npm`, `yarn`, or `pnpm`. |
+| `pnpm-version` | _(none)_ | pnpm version to install (pnpm only). Blank reads it from `packageManager` in `package.json`. See the pnpm note below. |
 | `cache-dependencies` | `true` | Cache the package manager's store between runs. |
 | `install-command` | _(auto)_ | Override the default install command. |
 | `node-version` | _(none)_ | Node.js version to set up. |
@@ -185,6 +186,7 @@ It runs against fixture projects (a single package and a multi-`tsconfig` worksp
 - **Pull-request events only.** The action compares HEAD vs BASE, so it expects a `pull_request` trigger.
 - **Custom Node/setup steps** belong _before_ this action if you need them.
 - **`tsconfig` must exist** where the action runs; otherwise `tsc` falls back to its defaults.
+- **pnpm needs a version.** With `package-manager: pnpm`, either set `pnpm-version` or add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` (e.g. `"packageManager": "pnpm@9.15.4"`). Without one, `pnpm/action-setup` errors with _"No pnpm version is specified."_
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: Package manager to use (npm, yarn, or pnpm)
     required: false
     default: 'npm'
+  pnpm-version:
+    description: |
+      pnpm version to install (only used when package-manager is pnpm).
+      Leave blank to read it from the package.json "packageManager" field.
+    required: false
   cache-dependencies:
     description: Whether to enable dependency caching
     required: false
@@ -83,6 +88,7 @@ runs:
       uses: thinkdx/ts-stricter/install@v2
       with:
         package-manager: ${{ inputs.package-manager }}
+        pnpm-version: ${{ inputs.pnpm-version }}
         working-directory: ${{ inputs.working-directory }}
         cache-dependencies: ${{ inputs.cache-dependencies }}
         install-command: ${{ inputs.install-command }}
@@ -118,6 +124,7 @@ runs:
       uses: thinkdx/ts-stricter/install@v2
       with:
         package-manager: ${{ inputs.package-manager }}
+        pnpm-version: ${{ inputs.pnpm-version }}
         working-directory: ${{ inputs.working-directory }}
         cache-dependencies: ${{ inputs.cache-dependencies }}
         install-command: ${{ inputs.install-command }}

--- a/install/action.yml
+++ b/install/action.yml
@@ -7,6 +7,12 @@ inputs:
     description: Package manager to use (npm, yarn, or pnpm)
     required: false
     default: 'npm'
+  pnpm-version:
+    description: |
+      pnpm version to install (only used when package-manager is pnpm).
+      Leave blank to let pnpm/action-setup read the version from your
+      package.json "packageManager" field. One of the two is required for pnpm.
+    required: false
   working-directory:
     description: Directory containing package.json
     required: false
@@ -33,6 +39,9 @@ runs:
     - name: Install pnpm
       if: ${{ inputs.package-manager == 'pnpm' }}
       uses: pnpm/action-setup@v4
+      with:
+        # Empty falls back to the package.json "packageManager" field.
+        version: ${{ inputs.pnpm-version }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
Adds an optional `pnpm-version` input so `package-manager: pnpm` works without requiring a `packageManager` field in `package.json`.

## Why
The testbed (TestTsStricter) surfaced that `pnpm/action-setup@v4` fails with a cryptic **"No pnpm version is specified"** when neither an explicit version nor a `packageManager` field is present. Anyone enabling `package-manager: pnpm` hits this with no obvious cause.

## Change
- `install/action.yml`: new `pnpm-version` input, passed to `pnpm/action-setup`'s `version`. Blank → falls back to the `packageManager` field (unchanged behavior).
- `action.yml`: same input, threaded to both install steps.
- `README.md`: input table row + a note explaining pnpm needs **either** `pnpm-version` **or** a `packageManager` field.

## Validation
- All 4 composite YAMLs parse; local suite green (24/24).
- Behavior already proven in CI: the testbed's `workspace-pnpm` PRs pass using the `packageManager`-field path (the blank-input fallback). `pnpm-version` simply gives users the explicit alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)